### PR TITLE
[ENH] Baseline selection from the panel

### DIFF
--- a/gui/panel_brainentropy.m
+++ b/gui/panel_brainentropy.m
@@ -1362,7 +1362,17 @@ end
 % (why not giving precedence to the studies currently selected for analyses?)
 S = getfield(bst_get('ProtocolStudies'), 'Study');
 S = [S.Data];
-S(~strcmp({S.DataType}, 'recordings')) = [];
+
+tmp = cellfun(@(x) strsplit(x,'/'), {S.FileName}, 'UniformOutput', false);
+subjectNames = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
+conditionNames = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
+
+S   = S( strcmp({S.DataType}, 'recordings') & ... 
+         strcmp(subjectNames, MEMglobal.SubjToProcess));
+
+tmp = cellfun(@(x) strsplit(x,'/'), {S.FileName}, 'UniformOutput', false);
+subjectNames = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
+conditionNames = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
 
 % This should never happen
 if isempty(S)
@@ -1385,11 +1395,8 @@ success = true;
 % Warning if multiple recordings are valid
 if (nnz(K) > 1)
     potentials_baseline = S(K);
-    tmp = cellfun(@(x) strsplit(x,'/'), {potentials_baseline.FileName}, 'UniformOutput', false);
-    subjectName = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
-    conditionName = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
 
-    names = strcat(subjectName', {' /  '},conditionName' ,{' /  '} , {potentials_baseline.Comment}');
+    names = strcat(subjectNames(K)', {' /  '},conditionNames(K)' ,{' /  '} , {potentials_baseline.Comment}');
     try
         ChanSelected = java_dialog('radio', 'Select baseline to use:', 'Baseline selection', [], names);
     catch 
@@ -1401,9 +1408,8 @@ if (nnz(K) > 1)
         return
     end
     K = K(ChanSelected);
-else
-
 end
+
 disp('BEst> Selecting the baseline file:')
 disp(['BEst>    ''', S(K(1)).FileName, ''''])
 

--- a/gui/panel_brainentropy.m
+++ b/gui/panel_brainentropy.m
@@ -1384,8 +1384,24 @@ success = true;
 
 % Warning if multiple recordings are valid
 if (nnz(K) > 1)
-    disp(['BEst> Multiple recordings in the current protocol have ''', ...
-        bsl_name, ''' in their name'])
+    potentials_baseline = S(K);
+    tmp = cellfun(@(x) strsplit(x,'/'), {potentials_baseline.FileName}, 'UniformOutput', false);
+    tmp = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
+    
+    names = strcat(tmp', {' /  '} , {potentials_baseline.Comment}');
+    try
+        ChanSelected = java_dialog('radio', 'Select baseline to use:', 'Baseline selection', [], names);
+    catch 
+        disp(['BEst> No baseline selected'])
+        return
+    end
+    if isempty(ChanSelected)
+        disp(['BEst> No baseline selected'])
+        return
+    end
+    K = K(ChanSelected);
+else
+
 end
 disp('BEst> Selecting the baseline file:')
 disp(['BEst>    ''', S(K(1)).FileName, ''''])

--- a/gui/panel_brainentropy.m
+++ b/gui/panel_brainentropy.m
@@ -1363,22 +1363,26 @@ end
 S = getfield(bst_get('ProtocolStudies'), 'Study');
 S = [S.Data];
 
-tmp = cellfun(@(x) strsplit(x,'/'), {S.FileName}, 'UniformOutput', false);
-subjectNames = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
-conditionNames = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
-
-S   = S( strcmp({S.DataType}, 'recordings') & ... 
-         strcmp(subjectNames, MEMglobal.SubjToProcess));
-
-tmp = cellfun(@(x) strsplit(x,'/'), {S.FileName}, 'UniformOutput', false);
-subjectNames = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
-conditionNames = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
-
 % This should never happen
 if isempty(S)
     disp('BEst> No study with recordings found in the current protocol.')
     return
 end
+
+
+tmp = cellfun(@(x) strsplit(x,'/'), {S.FileName}, 'UniformOutput', false);
+subjectNames = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
+conditionNames = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
+
+idx = false(size(subjectNames));
+for iSubject = 1:length(MEMglobal.SubjToProcess)
+    idx = idx | strcmp(subjectNames,MEMglobal.SubjToProcess{iSubject});
+end
+idx = idx & strcmp({S.DataType}, 'recordings');
+
+S               = S(idx);
+subjectNames    = subjectNames(idx);
+conditionNames  =  conditionNames(idx);
 
 K = find(cellfun(@(k) ~isempty(k), strfind({S.Comment}, bsl_name)));
 

--- a/gui/panel_brainentropy.m
+++ b/gui/panel_brainentropy.m
@@ -1386,9 +1386,10 @@ success = true;
 if (nnz(K) > 1)
     potentials_baseline = S(K);
     tmp = cellfun(@(x) strsplit(x,'/'), {potentials_baseline.FileName}, 'UniformOutput', false);
-    tmp = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
-    
-    names = strcat(tmp', {' /  '} , {potentials_baseline.Comment}');
+    subjectName = cellfun(@(x) x{1}, tmp, 'UniformOutput', false);
+    conditionName = cellfun(@(x) x{2}, tmp, 'UniformOutput', false);
+
+    names = strcat(subjectName', {' /  '},conditionName' ,{' /  '} , {potentials_baseline.Comment}');
     try
         ChanSelected = java_dialog('radio', 'Select baseline to use:', 'Baseline selection', [], names);
     catch 


### PR DESCRIPTION
If multiple baselines are found in the brainstorm database, ask the user to select the baseline instead of selecting the first file, which would often be a wrong choice. 

![Screenshot 2023-10-05 at 18 29 44](https://github.com/multifunkim/best-brainstorm/assets/24530402/6eb04c77-2e93-4c08-b6c7-59ceadcecfb9)

To avoid showing too many baseline, only show the baseline of the subject