### PR TITLE
Hide expert panels in normal mode Close #17 

### DIFF
--- a/gui/panel_brainentropy.m
+++ b/gui/panel_brainentropy.m
@@ -808,7 +808,9 @@ function [bstPanelNew, panelName] = CreatePanel(OPTIONS,varargin)  %#ok<DEFNU>
     end
         
     if ~firstCall
-        jPanelNew.add('right', jPanelNewR);
+        if OPTIONS.automatic.MEMexpert
+            jPanelNew.add('right', jPanelNewR);
+        end
     end
 
     %% ----------------------------------------------------------------- %%
@@ -935,7 +937,9 @@ function [bstPanelNew, panelName] = CreatePanel(OPTIONS,varargin)  %#ok<DEFNU>
         ExpertMEM   = OPTIONS.automatic.MEMexpert;
         ctrl.jButEXP.setText( choices{ExpertMEM+1} );
         
-        UpdatePanel;        
+        % To show / hide the expert panel, simulate a pipeline switch.
+        % UpdatePanel;      
+        SwitchPipeline;
     end   
 
     %% ===== SWITCH PIPELINE =====

--- a/gui/panel_brainentropy.m
+++ b/gui/panel_brainentropy.m
@@ -807,10 +807,8 @@ function [bstPanelNew, panelName] = CreatePanel(OPTIONS,varargin)  %#ok<DEFNU>
         jPanelNewR.add('br hfill', jPanelRDG);
     end
         
-    if ~firstCall
-        if OPTIONS.automatic.MEMexpert
-            jPanelNew.add('right', jPanelNewR);
-        end
+    if (~firstCall) & OPTIONS.automatic.MEMexpert
+        jPanelNew.add('right', jPanelNewR);
     end
 
     %% ----------------------------------------------------------------- %%


### PR DESCRIPTION
PR on "master" branch, "develop" branch seems inactive

In normal mode, expert panels are hidden : 
![normal_mode](https://github.com/multifunkim/best-brainstorm/assets/35274812/461839d1-0bc1-49a4-b4d5-c0578a5a7ed2)

Clicking on the "Expert" button enables expert mode, which displays expert panels :
![expert_mode](https://github.com/multifunkim/best-brainstorm/assets/35274812/8e851649-6665-4d28-9ba0-244794a96492)

Close #17 