### PR TITLE
optimize cMEM stable clustering

### DIFF
--- a/best/cmem/clusters/be_stable_clustering_multim.m
+++ b/best/cmem/clusters/be_stable_clustering_multim.m
@@ -132,10 +132,8 @@ end
 % Contains labels ranging from 0 to number of parcels (1 column / time sample) for each sources.
 
 nb_time = size(SCR,2);
-CLS     = zeros(nbS, nb_time);
+[OPTIONS, CLS,cellstruct_cls] = be_create_clusters(VertConn, mean(SCR,2), OPTIONS );
+CLS = repmat(CLS,1, nb_time);
 
-for i = 1:nb_time
-    [OPTIONS, CLS(:,i),cellstruct_cls] = be_create_clusters(VertConn, mean(SCR,2), OPTIONS );
-end
 
 end

--- a/best/msp/be_msp.m
+++ b/best/msp/be_msp.m
@@ -87,8 +87,7 @@ Ut = Gstruct.U(:,sort(i_T));
 
 % Create the projector.
 Ms = Ut*Ut'*Mn;
-Ps = Ms * pinv(Ms'*Ms) * Ms';
-clear Ms Ut R2 gamma C Mn indices i_T M
+Ps = Ms * pinv(Ms);
 
 % Calculate the MSP scores.
 Ps2=Ps*Gstruct.Gn;


### PR DESCRIPTION
- Avoid repetitive computation
- Use     Ps = Ms * pinv(Ms); instead of  Ps = Ms * pinv(Ms'*Ms) * Ms'; (equivalent but faster)