### PR TITLE
Allow to choose the scale used for covariance matrix (wMEM)

### DIFF
--- a/best/wmem/preprocess/be_wdata_preprocessing.m
+++ b/best/wmem/preprocess/be_wdata_preprocessing.m
@@ -185,15 +185,10 @@ function [noise_var] = estimate_noise_var(OPTIONS)
 
                 case 6
                     % Scale one which the noise covariance is calculated
-                    if strcmp(OPTIONS.automatic.Modality(ii).name, 'NIRS')
-                        isc = 3;
-                    else
-                        isc = 2; 
-                    end
+                    isc = DEF.wavelet.selected_scales_baseline;
                     
                     % Select the wavelet coefficient for scale isc
                     % (exclude the 5 first and last boxes) 
-
                     w1 = wavelet_obj.data{1}(:,end/2^(isc)+6:end/2^(isc-1)-5)';
 
                     % The following code might be more robust but needs to

--- a/best/wmem/preprocess/be_wdata_preprocessing.m
+++ b/best/wmem/preprocess/be_wdata_preprocessing.m
@@ -185,7 +185,7 @@ function [noise_var] = estimate_noise_var(OPTIONS)
 
                 case 6
                     % Scale one which the noise covariance is calculated
-                    isc = DEF.wavelet.selected_scales_covariance;
+                    isc = OPTIONS.wavelet.selected_scales_covariance;
                     
                     % Select the wavelet coefficient for scale isc
                     % (exclude the 5 first and last boxes) 

--- a/best/wmem/preprocess/be_wdata_preprocessing.m
+++ b/best/wmem/preprocess/be_wdata_preprocessing.m
@@ -185,7 +185,7 @@ function [noise_var] = estimate_noise_var(OPTIONS)
 
                 case 6
                     % Scale one which the noise covariance is calculated
-                    isc = DEF.wavelet.selected_scales_baseline;
+                    isc = DEF.wavelet.selected_scales_covariance;
                     
                     % Select the wavelet coefficient for scale isc
                     % (exclude the 5 first and last boxes) 

--- a/best/wmem/solver/be_wmem_pipelineoptions.m
+++ b/best/wmem/solver/be_wmem_pipelineoptions.m
@@ -41,6 +41,11 @@ function DEF = be_wmem_pipelineoptions(DataTypes)
         DEF.wavelet.nb_levels           = 128;
         DEF.wavelet.shrinkage           = 0;
         DEF.wavelet.selected_scales     = 0;
+        if any(ismember( 'nirs', lower(DataTypes)))
+            DEF.wavelet.selected_scales_baseline     = 3;
+        else
+            DEF.wavelet.selected_scales_baseline     = 2;
+        end
         DEF.wavelet.verbose             = 0;
         DEF.wavelet.single_box          = 0;
         

--- a/best/wmem/solver/be_wmem_pipelineoptions.m
+++ b/best/wmem/solver/be_wmem_pipelineoptions.m
@@ -42,9 +42,9 @@ function DEF = be_wmem_pipelineoptions(DataTypes)
         DEF.wavelet.shrinkage           = 0;
         DEF.wavelet.selected_scales     = 0;
         if any(ismember( 'nirs', lower(DataTypes)))
-            DEF.wavelet.selected_scales_baseline     = 3;
+            DEF.wavelet.selected_scales_covariance     = 3;
         else
-            DEF.wavelet.selected_scales_baseline     = 2;
+            DEF.wavelet.selected_scales_covariance     = 2;
         end
         DEF.wavelet.verbose             = 0;
         DEF.wavelet.single_box          = 0;


### PR DESCRIPTION
Keep the default value of 2 for EEG/MEG and 3 for fNIRS but allow to change it by passing OPTIONS.wavelet.selected_scales_covariance