### PR TITLE
fix baseline loading for fNIRS (within brainstorm)

### DIFF
--- a/best/misc/be_initialize_options.m
+++ b/best/misc/be_initialize_options.m
@@ -82,6 +82,8 @@ function [OPTIONS, FLAG, verbose] = be_initialize_options(OPTIONS)
 
     if isfield(OPTIONS.optional, 'BaselineChannels') && isstruct(OPTIONS.optional.BaselineChannels) && ~isempty(OPTIONS.optional.BaselineChannels) && isfield(OPTIONS.optional.BaselineChannels(1), 'Name')
         OPTIONS.optional.BaselineChannels = {OPTIONS.optional.BaselineChannels.Name}; 
+    elseif isfield(OPTIONS.optional, 'BaselineChannels') && isstruct(OPTIONS.optional.BaselineChannels) &&  isfield(OPTIONS.optional.BaselineChannels, 'Channel') && ~isempty(OPTIONS.optional.BaselineChannels.Channel) && isfield(OPTIONS.optional.BaselineChannels.Channel(1), 'Name')
+        OPTIONS.optional.BaselineChannels = {OPTIONS.optional.BaselineChannels.Channel.Name}; 
     end
 
     % Reorder Baseline channels


### PR DESCRIPTION
fix an error when using baseline within Brainstorm for fNIRS.